### PR TITLE
Update the location of shared GitHub configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,1 +1,1 @@
-_extends: probot-config-next
+_extends: github-apps-config-next

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,1 @@
-_extends: probot-config-next
+_extends: github-apps-config-next


### PR DESCRIPTION
Relates to https://github.com/Financial-Times/github-apps-config-next/pull/9.